### PR TITLE
Fix typo in summary

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,7 +1,7 @@
 {
   "type": "package",
   "name": "wolfadex/elm-ansi",
-  "summary": "Functions and types to make it easy to work with ASNI codes and the terminal",
+  "summary": "Functions and types to make it easy to work with ANSI codes and the terminal",
   "license": "BSD-3-Clause",
   "version": "1.0.0",
   "exposed-modules": [


### PR DESCRIPTION
This is visible in the package listing.

That said, the summary is not the same as in the README. Maybe they should be? If so, I don't know which one you prefer.